### PR TITLE
Fix a tyop in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-mkdir -p ~/.vim/plugins
+mkdir -p ~/.vim/plugin
 cp plugin/script-runner.vim ~/.vim/plugin


### PR DESCRIPTION
~/.vim/plugins was being created, but the file is being copied to ~/.vim/plugin
