### PR TITLE
Add exit code at the end of script execution

### DIFF
--- a/plugin/script-runner.vim
+++ b/plugin/script-runner.vim
@@ -80,7 +80,7 @@ fu! Run(cmd)
     resize 12
     " }}}
     0 put
-    exe '%!' . s:real_cmd
+    exe '%!' . s:real_cmd . '; echo -e "------------------------------------\nScript exited with code: $?"'
     0 read !date
     append
 ------------------------------------


### PR DESCRIPTION
Exit codes matter.
Add a separator and a line showing the exit code after executing the script (or the interpreter's exit code if the script failed during execution).